### PR TITLE
Fix typo in accessors for DashboardContext.dashboardPersister

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A view can be for example a chart or a table.
 - **WidgetFactory** is the object that creates widgets using the widget descriptors.
 - **WidgetRegistry** is the object that stores all active widget descriptors. You can register a new widget 
 using a widget descriptor.
-- **DashboardPersiter** is responsible for dashboard load and save. XStreamDashboardPersister is a concrete implementation
+- **DashboardPersister** is responsible for dashboard load and save. XStreamDashboardPersister is a concrete implementation
 that save/load a dashboard to/from a file.
 - **DashboardPanel** is a wicket panel that displays a dashboard.
 - **WidgetPanel** is a wicket panel that displays a widget. It contains a header panel, a settings panel (if the
@@ -142,7 +142,7 @@ In your application class make some initializations:
 	}
 	
 	private void initDashboard() {
-		dashboard = getDashboardContext().getDashboardPersiter().load();
+		dashboard = getDashboardContext().getDashboardPersister().load();
     	if (dashboard == null) {
     		dashboard = new DefaultDashboard("default", "Default");
     	}

--- a/core/src/main/java/ro/fortsoft/wicket/dashboard/web/DashboardContext.java
+++ b/core/src/main/java/ro/fortsoft/wicket/dashboard/web/DashboardContext.java
@@ -36,7 +36,7 @@ public class DashboardContext {
 	public DashboardContext() {
 		setWidgetFactory(new DefaultWidgetFactory());
 		setWidgetRegistry(new DefaultWidgetRegistry());
-		setDashboardPersiter(new XStreamDashboardPersister(new File("dashboard.xml")));
+		setDashboardPersister(new XStreamDashboardPersister(new File("dashboard.xml")));
 		setWidgetActionsFactory(new DefaultWidgetActionsFactory());
 	}
 	
@@ -56,11 +56,27 @@ public class DashboardContext {
 		this.widgetRegistry = widgetRegistry;
 	}
 
+	/**
+	 * @deprecated use {@link #getDashboardPersister()} instead
+	 */
+	@Deprecated
 	public DashboardPersister getDashboardPersiter() {
 		return dashboardPersister;
 	}
 
+	public DashboardPersister getDashboardPersister() {
+		return dashboardPersister;
+	}
+
+	/**
+	 * @deprecated use {@link #setDashboardPersister(DashboardPersister)} instead
+	 */
+	@Deprecated
 	public void setDashboardPersiter(DashboardPersister dashboardPersister) {
+		this.dashboardPersister = dashboardPersister;
+	}
+
+	public void setDashboardPersister(DashboardPersister dashboardPersister) {
 		this.dashboardPersister = dashboardPersister;
 	}
 

--- a/core/src/main/java/ro/fortsoft/wicket/dashboard/web/DashboardPanel.java
+++ b/core/src/main/java/ro/fortsoft/wicket/dashboard/web/DashboardPanel.java
@@ -83,7 +83,7 @@ public class DashboardPanel extends GenericPanel<Dashboard> implements Dashboard
 		Dashboard dashboard = getDashboard();
 		DashboardUtils.updateWidgetLocations(dashboard, dashboardEvent);
 		dashboard.addWidget(addedWidget);
-		dashboardContext.getDashboardPersiter().save(dashboard);
+		dashboardContext.getDashboardPersister().save(dashboard);
 	}
 
 	private void onWidgetRemoved(DashboardEvent dashboardEvent) {
@@ -91,13 +91,13 @@ public class DashboardPanel extends GenericPanel<Dashboard> implements Dashboard
 		Dashboard dashboard = getDashboard();
 		DashboardUtils.updateWidgetLocations(dashboard, dashboardEvent);
 		dashboard.deleteWidget(removedWidget.getId());
-		dashboardContext.getDashboardPersiter().save(dashboard);
+		dashboardContext.getDashboardPersister().save(dashboard);
 	}
 
 	protected void onWidgetsSorted(DashboardEvent dashboardEvent) {
 		Dashboard dashboard = getDashboard();
 		DashboardUtils.updateWidgetLocations(dashboard, dashboardEvent);
-		dashboardContext.getDashboardPersiter().save(dashboard);		
+		dashboardContext.getDashboardPersister().save(dashboard);
 	}
 
 	private void addColumnsPanel() {

--- a/core/src/main/java/ro/fortsoft/wicket/dashboard/web/WidgetHeaderPanel.java
+++ b/core/src/main/java/ro/fortsoft/wicket/dashboard/web/WidgetHeaderPanel.java
@@ -67,7 +67,7 @@ public class WidgetHeaderPanel extends GenericPanel<Widget> implements Dashboard
 
 				// save the new state of widget/dashboard
 				Dashboard dashboard = findParent(DashboardPanel.class).getDashboard();
-				dashboardContext.getDashboardPersiter().save(dashboard);
+				dashboardContext.getDashboardPersister().save(dashboard);
 
 				// change toggle's image
 				target.add(toggle);

--- a/demo/src/main/java/ro/fortsoft/wicket/dashboard/demo/AddWidgetPanel.java
+++ b/demo/src/main/java/ro/fortsoft/wicket/dashboard/demo/AddWidgetPanel.java
@@ -132,7 +132,7 @@ public class AddWidgetPanel extends GenericPanel<Dashboard> implements Dashboard
 					Dashboard dashboard = getDashboard();
 					DashboardUtils.updateWidgetLocations(dashboard, new DashboardEvent(target, DashboardEvent.EventType.WIDGET_ADDED, widget));
 					dashboard.addWidget(widget);
-					dashboardContext.getDashboardPersiter().save(dashboard);
+					dashboardContext.getDashboardPersister().save(dashboard);
 					message = "added";
 					label.setVisible(true);
 					target.add(label);

--- a/demo/src/main/java/ro/fortsoft/wicket/dashboard/demo/WicketApplication.java
+++ b/demo/src/main/java/ro/fortsoft/wicket/dashboard/demo/WicketApplication.java
@@ -110,7 +110,7 @@ public class WicketApplication extends WebApplication {
 	}
 	
 	private void initDashboard() {
-		dashboard = getDashboardContext().getDashboardPersiter().load();
+		dashboard = getDashboardContext().getDashboardPersister().load();
     	if (dashboard == null) {
     		dashboard = new DefaultDashboard("default", "Default");
     	}

--- a/widgets/jqplot/src/main/java/ro/fortsoft/wicket/dashboard/widget/jqplot/JqPlotSettingsPanel.java
+++ b/widgets/jqplot/src/main/java/ro/fortsoft/wicket/dashboard/widget/jqplot/JqPlotSettingsPanel.java
@@ -58,7 +58,7 @@ public class JqPlotSettingsPanel extends GenericPanel<JqPlotWidget> implements D
 			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
             	getModelObject().getSettings().put("chartType", chartType);
 				Dashboard dashboard = findParent(DashboardPanel.class).getDashboard();
-				dashboardContext.getDashboardPersiter().save(dashboard);
+				dashboardContext.getDashboardPersister().save(dashboard);
 
             	hideSettingPanel(target);
             	// TODO

--- a/widgets/ofchart/src/main/java/ro/fortsoft/wicket/dashboard/widget/ofchart/ChartSettingsPanel.java
+++ b/widgets/ofchart/src/main/java/ro/fortsoft/wicket/dashboard/widget/ofchart/ChartSettingsPanel.java
@@ -58,7 +58,7 @@ public class ChartSettingsPanel extends GenericPanel<ChartWidget> implements Das
 			protected void onSubmit(AjaxRequestTarget target, Form<?> form) {
             	getModelObject().getSettings().put("chartType", chartType);
 				Dashboard dashboard = findParent(DashboardPanel.class).getDashboard();
-				dashboardContext.getDashboardPersiter().save(dashboard);
+				dashboardContext.getDashboardPersister().save(dashboard);
 
             	hideSettingPanel(target);
             	// TODO

--- a/widgets/ofchart/src/main/java/ro/fortsoft/wicket/dashboard/widget/ofchart/DataResourceReference.java
+++ b/widgets/ofchart/src/main/java/ro/fortsoft/wicket/dashboard/widget/ofchart/DataResourceReference.java
@@ -39,7 +39,7 @@ public class DataResourceReference extends ResourceReference {
 	// TODO
 	private Dashboard getDashboard() {
 		DashboardContext dashboardContext = Application.get().getMetaData(DashboardContextInitializer.DASHBOARD_CONTEXT_KEY);
-		Dashboard dashboard = dashboardContext.getDashboardPersiter().load();
+		Dashboard dashboard = dashboardContext.getDashboardPersister().load();
 		
 		return dashboard;
 	}

--- a/widgets/wicked-charts/src/main/java/ro/fortsoft/wicket/dashboard/widgets/wicked/charts/settings/HighChartsSettingsPanel.java
+++ b/widgets/wicked-charts/src/main/java/ro/fortsoft/wicket/dashboard/widgets/wicked/charts/settings/HighChartsSettingsPanel.java
@@ -62,7 +62,7 @@ public class HighChartsSettingsPanel extends GenericPanel<HighChartsWidget> impl
                 getModelObject().updateChart();
 
                 Dashboard dashboard = findParent(DashboardPanel.class).getDashboard();
-                dashboardContext.getDashboardPersiter().save(dashboard);
+                dashboardContext.getDashboardPersister().save(dashboard);
 
                 hideSettingPanel(target);
 


### PR DESCRIPTION
While looking around the doc and project to get the hang on how to use it, I've been buggered by that typo (missing `s`) on accessors for `DashboardPersister` property in `DashboardContext`.

So here's a pull request to rename the offending methods (both in the class and where they are called in the project), while keeping the previous ones as _deprecated_ in order to avoid breaking users' projects.

Those deprecated method with the typo should be removed later on.
