### PR TITLE
'onclick' was renamed to 'click'

### DIFF
--- a/core/src/main/java/ro/fortsoft/wicket/dashboard/web/WidgetHeaderPanel.java
+++ b/core/src/main/java/ro/fortsoft/wicket/dashboard/web/WidgetHeaderPanel.java
@@ -54,7 +54,7 @@ public class WidgetHeaderPanel extends GenericPanel<Widget> implements Dashboard
         };
 
         toggle.setOutputMarkupId(true);
-        toggle.add(new AjaxEventBehavior("onclick") {
+        toggle.add(new AjaxEventBehavior("click") {
 
 			private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
due to "Since version 6.0.0 Wicket uses JavaScript event registration so there is no need of the leading 'on' in the event name '{}'. Please use just '{}'. Wicket 8.x won't manipulate the provided event names so the leading 'on' may break your application."